### PR TITLE
Removing rules from build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.1
+
+### Changed
+
+Remove (via commenting) from build.sh the lines which download the rules. These will
+now need to be downloaded by the user.
+
+## 1.0.0
+
+this is the first 'release' on github with the intention of creating releases for
+bioconda
+
 ## [Unreleased]
 
 ### Added

--- a/build.sh
+++ b/build.sh
@@ -52,18 +52,18 @@ echo "Done building UniFIRE and downloading dependencies."
 
 popd > /dev/null
 
-unirule_version="$(grep -E "^URML_RULES_VERSION=" "${SCRIPT_DIR}"/docker/versions.properties | cut -d '=' -f 2)"
+# unirule_version="$(grep -E "^URML_RULES_VERSION=" "${SCRIPT_DIR}"/docker/versions.properties | cut -d '=' -f 2)"
 
-echo "Downloading rule urml files..."
-for file_prefix in arba-urml unirule-urml unirule-templates unirule.pirsr-urml;
-do
-    wget ${FTP_SRC}/${file_prefix}-${unirule_version}.xml -O ${SCRIPT_DIR}/samples/${file_prefix}-latest.xml
-done
-echo "Done downloading rule urml files."
+# echo "Downloading rule urml files..."
+# for file_prefix in arba-urml unirule-urml unirule-templates unirule.pirsr-urml;
+# do
+#     wget ${FTP_SRC}/${file_prefix}-${unirule_version}.xml -O ${SCRIPT_DIR}/samples/${file_prefix}-latest.xml
+# done
+# echo "Done downloading rule urml files."
 
-PIRSR_DATA_SRC="https://proteininformationresource.org/pirsr/pirsr_data_latest.tar.gz"
-echo "Download pirsr data files..."
-wget ${PIRSR_DATA_SRC} -O ${SCRIPT_DIR}/samples/pirsr_data_latest.tar.gz
-echo "untarring pirsr_data..."
-tar -zxf ${SCRIPT_DIR}/samples/pirsr_data_latest.tar.gz -C ${SCRIPT_DIR}/samples/
-echo "Done download pirsr data files."
+# PIRSR_DATA_SRC="https://proteininformationresource.org/pirsr/pirsr_data_latest.tar.gz"
+# echo "Download pirsr data files..."
+# wget ${PIRSR_DATA_SRC} -O ${SCRIPT_DIR}/samples/pirsr_data_latest.tar.gz
+# echo "untarring pirsr_data..."
+# tar -zxf ${SCRIPT_DIR}/samples/pirsr_data_latest.tar.gz -C ${SCRIPT_DIR}/samples/
+# echo "Done download pirsr data files."


### PR DESCRIPTION
this also removes `wget` as a build dependency. It was, not it is not.